### PR TITLE
テーブルの並び順の矢印のバグを修正

### DIFF
--- a/components/ClickableHeader.tsx
+++ b/components/ClickableHeader.tsx
@@ -15,6 +15,10 @@ interface Props {
     | HeaderType.HIT
     | HeaderType.COUNTER;
   title: string;
+  // TODO: 変数型をつける
+  updateHeader: (type: any) => void;
+  isActive: boolean;
+  isAscending: boolean;
 }
 
 const Logo = {
@@ -23,33 +27,12 @@ const Logo = {
 };
 
 const ClickableHeader: NextPage<Props> = (props) => {
-  const { type, title } = props;
-  const [isActive, setActive] = useState(false);
-  const [isAscending, setAscending] = useState(false);
-  const [isDescending, setDescending] = useState(false);
-  const [iconText, setIconText] = useState(Logo.DESCENDING);
+  const { type, title, updateHeader, isActive, isAscending } = props;
   const dispatch = useDispatch();
 
   const clickTableIcon = () => {
-    dispatch(updateFrameDataList({ type, isAscending, isDescending }));
-    if (!isActive) {
-      setActive(!isActive);
-      setAscending(true);
-    } else if (!isAscending) {
-      setAscending(true);
-      setDescending(false);
-      setIconText(Logo.DESCENDING);
-    } else if (isAscending && !isDescending) {
-      setAscending(false);
-      setDescending(true);
-      setIconText(Logo.ASCENDING);
-    }
-  };
-
-  const reset = () => {
-    setActive(false);
-    setAscending(false);
-    setDescending(false);
+    dispatch(updateFrameDataList({ type, isAscending }));
+    updateHeader(type);
   };
 
   const tableIconClassName = [styles.tableIcon];
@@ -63,7 +46,7 @@ const ClickableHeader: NextPage<Props> = (props) => {
       <span
         className={`${styles.tableIcon} ${isActive && styles['js-active']}`}
       >
-        {iconText}
+        {isAscending ? Logo.DESCENDING : Logo.ASCENDING}
       </span>
     </th>
   );

--- a/components/ClickableHeader.tsx
+++ b/components/ClickableHeader.tsx
@@ -15,8 +15,13 @@ interface Props {
     | HeaderType.HIT
     | HeaderType.COUNTER;
   title: string;
-  // TODO: 変数型をつける
-  updateHeader: (type: any) => void;
+  handleTableHeaderStatus: (
+    type:
+      | HeaderType.START_UP
+      | HeaderType.BLOCK
+      | HeaderType.HIT
+      | HeaderType.COUNTER
+  ) => void;
   isActive: boolean;
   isAscending: boolean;
 }
@@ -27,12 +32,12 @@ const Logo = {
 };
 
 const ClickableHeader: NextPage<Props> = (props) => {
-  const { type, title, updateHeader, isActive, isAscending } = props;
+  const { type, title, handleTableHeaderStatus, isActive, isAscending } = props;
   const dispatch = useDispatch();
 
   const clickTableIcon = () => {
     dispatch(updateFrameDataList({ type, isAscending }));
-    updateHeader(type);
+    handleTableHeaderStatus(type);
   };
 
   const tableIconClassName = [styles.tableIcon];

--- a/components/FrameDataTableHeader.tsx
+++ b/components/FrameDataTableHeader.tsx
@@ -9,137 +9,123 @@ import ClickableHeader from './ClickableHeader';
 
 interface Props {}
 
-// TODO: 適切な変数名に変更
-type HeaderItem = {
+type HeaderState = {
   isActive: boolean;
   isAscending: boolean;
 };
 
-// TODO: 適切な変数名に変更
-const HeaderShurui = {
-  startup: 0,
-  block: 1,
-  hit: 2,
-  counterHit: 3,
-} as const;
+const FrameDataTableHeader: NextPage<Props> = () => {
+  const [startupState, setStartup] = useState<HeaderState>({
+    isActive: false,
+    isAscending: false,
+  });
+  const [blockState, setBlock] = useState<HeaderState>({
+    isActive: false,
+    isAscending: false,
+  });
+  const [hitState, setHit] = useState<HeaderState>({
+    isActive: false,
+    isAscending: false,
+  });
+  const [counterHitState, setCounterHit] = useState<HeaderState>({
+    isActive: false,
+    isAscending: false,
+  });
 
-const FrameDataTableHeader: NextPage<Props> = (props) => {
-  // TODO: 重複コードを削除
-  const [startup, setStartup] = useState<HeaderItem>({
-    isActive: false,
-    isAscending: false,
-  });
-  const [block, setBlock] = useState<HeaderItem>({
-    isActive: false,
-    isAscending: false,
-  });
-  const [hit, setHit] = useState<HeaderItem>({
-    isActive: false,
-    isAscending: false,
-  });
-  const [counterHit, setCounterHit] = useState<HeaderItem>({
-    isActive: false,
-    isAscending: false,
-  });
+  type IHeaderTab = {
+    isActive: boolean;
+    isAscending: boolean;
+  };
 
   const setBackToDefault = () => {
-    // TODO: 重複コードを削除
-    setStartup({
+    const defaultState: IHeaderTab = {
       isActive: false,
       isAscending: false,
+    };
+    setStartup({
+      ...defaultState,
     });
     setBlock({
-      isActive: false,
-      isAscending: false,
+      ...defaultState,
     });
     setHit({
-      isActive: false,
-      isAscending: false,
+      ...defaultState,
     });
     setCounterHit({
-      isActive: false,
-      isAscending: false,
+      ...defaultState,
     });
   };
 
-  // TODO: add type and delete any
-  // TODO: 重複コードを削除
-  const updateHeader = (type: any) => {
-    if (type === HeaderShurui.startup) {
-      if (!startup.isActive) {
-        setBackToDefault();
+  const updateHeaderState = (
+    type:
+      | HeaderType.START_UP
+      | HeaderType.BLOCK
+      | HeaderType.HIT
+      | HeaderType.COUNTER,
+    headerState: HeaderState
+  ) => {
+    let headerTabState: IHeaderTab = {
+      isActive: true,
+      // 昇順
+      isAscending: false,
+    };
+    if (!headerState.isActive) {
+      setBackToDefault();
+      headerTabState = {
+        isActive: true,
+        isAscending: true,
+      };
+    } else if (!headerState.isAscending) {
+      headerTabState = {
+        isActive: true,
+        // 降順
+        isAscending: true,
+      };
+    }
+    switch (type) {
+      case HeaderType.START_UP:
         setStartup({
-          isActive: true,
-          isAscending: true,
+          ...headerTabState,
         });
-      } else if (!startup.isAscending) {
-        setStartup({
-          isActive: true,
-          isAscending: true,
-        });
-      } else if (startup.isAscending) {
-        setStartup({
-          isActive: true,
-          isAscending: false,
-        });
-      }
-    } else if (type === HeaderShurui.block) {
-      if (!block.isActive) {
-        setBackToDefault();
+        break;
+      case HeaderType.BLOCK:
         setBlock({
-          isActive: true,
-          isAscending: true,
+          ...headerTabState,
         });
-      } else if (!block.isAscending) {
-        setBlock({
-          isActive: true,
-          isAscending: true,
-        });
-      } else if (block.isAscending) {
-        setBlock({
-          isActive: true,
-          isAscending: false,
-        });
-      }
-    } else if (type === HeaderShurui.hit) {
-      if (!hit.isActive) {
-        setBackToDefault();
+        break;
+      case HeaderType.HIT:
         setHit({
-          isActive: true,
-          isAscending: true,
+          ...headerTabState,
         });
-      } else if (!hit.isAscending) {
-        setHit({
-          isActive: true,
-          isAscending: true,
-        });
-      } else if (hit.isAscending) {
-        setHit({
-          isActive: true,
-          isAscending: false,
-        });
-      }
-    } else if (type === HeaderShurui.counterHit) {
-      if (!counterHit.isActive) {
-        setBackToDefault();
+        break;
+      case HeaderType.COUNTER:
         setCounterHit({
-          isActive: true,
-          isAscending: true,
+          ...headerTabState,
         });
-      } else if (!counterHit.isAscending) {
-        setCounterHit({
-          isActive: true,
-          isAscending: true,
-        });
-      } else if (counterHit.isAscending) {
-        setCounterHit({
-          isActive: true,
-          isAscending: false,
-        });
-      }
-    } else {
-      console.log('else');
-      // TODO
+        break;
+    }
+  };
+
+  const handleTableHeaderStatus = (
+    type:
+      | HeaderType.START_UP
+      | HeaderType.BLOCK
+      | HeaderType.HIT
+      | HeaderType.COUNTER
+  ) => {
+    switch (type) {
+      case HeaderType.START_UP:
+        updateHeaderState(HeaderType.START_UP, startupState);
+        break;
+      case HeaderType.BLOCK:
+        updateHeaderState(HeaderType.BLOCK, blockState);
+        break;
+      case HeaderType.HIT:
+        updateHeaderState(HeaderType.HIT, hitState);
+        break;
+      case HeaderType.COUNTER:
+        updateHeaderState(HeaderType.COUNTER, counterHitState);
+        break;
     }
   };
 
@@ -147,35 +133,34 @@ const FrameDataTableHeader: NextPage<Props> = (props) => {
     <tr>
       <th>Input</th>
       <ClickableHeader
-        updateHeader={updateHeader}
+        handleTableHeaderStatus={handleTableHeaderStatus}
         type={HeaderType.START_UP}
         title="Start up"
-        isActive={startup.isActive}
-        isAscending={startup.isAscending}
+        isActive={startupState.isActive}
+        isAscending={startupState.isAscending}
       />
       <th>Hit Type</th>
       <th>Damage</th>
-      {/* TODO: 重複コードを削除 */}
       <ClickableHeader
-        updateHeader={updateHeader}
+        handleTableHeaderStatus={handleTableHeaderStatus}
         type={HeaderType.BLOCK}
         title="Block"
-        isActive={block.isActive}
-        isAscending={block.isAscending}
+        isActive={blockState.isActive}
+        isAscending={blockState.isAscending}
       />
       <ClickableHeader
-        updateHeader={updateHeader}
+        handleTableHeaderStatus={handleTableHeaderStatus}
         type={HeaderType.HIT}
         title="Hit"
-        isActive={hit.isActive}
-        isAscending={hit.isAscending}
+        isActive={hitState.isActive}
+        isAscending={hitState.isAscending}
       />
       <ClickableHeader
-        updateHeader={updateHeader}
+        handleTableHeaderStatus={handleTableHeaderStatus}
         type={HeaderType.COUNTER}
         title="CH"
-        isActive={counterHit.isActive}
-        isAscending={counterHit.isAscending}
+        isActive={counterHitState.isActive}
+        isAscending={counterHitState.isAscending}
       />
     </tr>
   );

--- a/components/FrameDataTableHeader.tsx
+++ b/components/FrameDataTableHeader.tsx
@@ -9,17 +9,174 @@ import ClickableHeader from './ClickableHeader';
 
 interface Props {}
 
+// TODO: 適切な変数名に変更
+type HeaderItem = {
+  isActive: boolean;
+  isAscending: boolean;
+};
+
+// TODO: 適切な変数名に変更
+const HeaderShurui = {
+  startup: 0,
+  block: 1,
+  hit: 2,
+  counterHit: 3,
+} as const;
+
 const FrameDataTableHeader: NextPage<Props> = (props) => {
-  const [wasClicked, setClicked] = useState(false);
+  // TODO: 重複コードを削除
+  const [startup, setStartup] = useState<HeaderItem>({
+    isActive: false,
+    isAscending: false,
+  });
+  const [block, setBlock] = useState<HeaderItem>({
+    isActive: false,
+    isAscending: false,
+  });
+  const [hit, setHit] = useState<HeaderItem>({
+    isActive: false,
+    isAscending: false,
+  });
+  const [counterHit, setCounterHit] = useState<HeaderItem>({
+    isActive: false,
+    isAscending: false,
+  });
+
+  const setBackToDefault = () => {
+    // TODO: 重複コードを削除
+    setStartup({
+      isActive: false,
+      isAscending: false,
+    });
+    setBlock({
+      isActive: false,
+      isAscending: false,
+    });
+    setHit({
+      isActive: false,
+      isAscending: false,
+    });
+    setCounterHit({
+      isActive: false,
+      isAscending: false,
+    });
+  };
+
+  // TODO: add type and delete any
+  // TODO: 重複コードを削除
+  const updateHeader = (type: any) => {
+    if (type === HeaderShurui.startup) {
+      if (!startup.isActive) {
+        setBackToDefault();
+        setStartup({
+          isActive: true,
+          isAscending: true,
+        });
+      } else if (!startup.isAscending) {
+        setStartup({
+          isActive: true,
+          isAscending: true,
+        });
+      } else if (startup.isAscending) {
+        setStartup({
+          isActive: true,
+          isAscending: false,
+        });
+      }
+    } else if (type === HeaderShurui.block) {
+      if (!block.isActive) {
+        setBackToDefault();
+        setBlock({
+          isActive: true,
+          isAscending: true,
+        });
+      } else if (!block.isAscending) {
+        setBlock({
+          isActive: true,
+          isAscending: true,
+        });
+      } else if (block.isAscending) {
+        setBlock({
+          isActive: true,
+          isAscending: false,
+        });
+      }
+    } else if (type === HeaderShurui.hit) {
+      if (!hit.isActive) {
+        setBackToDefault();
+        setHit({
+          isActive: true,
+          isAscending: true,
+        });
+      } else if (!hit.isAscending) {
+        setHit({
+          isActive: true,
+          isAscending: true,
+        });
+      } else if (hit.isAscending) {
+        setHit({
+          isActive: true,
+          isAscending: false,
+        });
+      }
+    } else if (type === HeaderShurui.counterHit) {
+      if (!counterHit.isActive) {
+        setBackToDefault();
+        setCounterHit({
+          isActive: true,
+          isAscending: true,
+        });
+      } else if (!counterHit.isAscending) {
+        setCounterHit({
+          isActive: true,
+          isAscending: true,
+        });
+      } else if (counterHit.isAscending) {
+        setCounterHit({
+          isActive: true,
+          isAscending: false,
+        });
+      }
+    } else {
+      console.log('else');
+      // TODO
+    }
+  };
+
   return (
     <tr>
       <th>Input</th>
-      <ClickableHeader type={HeaderType.START_UP} title="Start up" />
+      <ClickableHeader
+        updateHeader={updateHeader}
+        type={HeaderType.START_UP}
+        title="Start up"
+        isActive={startup.isActive}
+        isAscending={startup.isAscending}
+      />
       <th>Hit Type</th>
       <th>Damage</th>
-      <ClickableHeader type={HeaderType.BLOCK} title="Block" />
-      <ClickableHeader type={HeaderType.HIT} title="Hit" />
-      <ClickableHeader type={HeaderType.COUNTER} title="CH" />
+      {/* TODO: 重複コードを削除 */}
+      <ClickableHeader
+        updateHeader={updateHeader}
+        type={HeaderType.BLOCK}
+        title="Block"
+        isActive={block.isActive}
+        isAscending={block.isAscending}
+      />
+      <ClickableHeader
+        updateHeader={updateHeader}
+        type={HeaderType.HIT}
+        title="Hit"
+        isActive={hit.isActive}
+        isAscending={hit.isAscending}
+      />
+      <ClickableHeader
+        updateHeader={updateHeader}
+        type={HeaderType.COUNTER}
+        title="CH"
+        isActive={counterHit.isActive}
+        isAscending={counterHit.isAscending}
+      />
     </tr>
   );
 };

--- a/reducer/frameDataSlice.ts
+++ b/reducer/frameDataSlice.ts
@@ -41,6 +41,7 @@ const orderColumn = (
       }
     });
   } else {
+    console.log('orderColumn: !isAscending');
     moves.sort(function (a: IFrameData, b: IFrameData) {
       if (type === HeaderType.START_UP) {
         return b.startUp - a.startUp;
@@ -69,7 +70,6 @@ const frameDataSlice = createSlice({
       action: PayloadAction<{
         type: HeaderType;
         isAscending: boolean;
-        isDescending: boolean;
       }>
     ) {
       const { type, isAscending } = action.payload;

--- a/reducer/frameDataSlice.ts
+++ b/reducer/frameDataSlice.ts
@@ -41,7 +41,6 @@ const orderColumn = (
       }
     });
   } else {
-    console.log('orderColumn: !isAscending');
     moves.sort(function (a: IFrameData, b: IFrameData) {
       if (type === HeaderType.START_UP) {
         return b.startUp - a.startUp;


### PR DESCRIPTION
## 概要
テーブルの並び順（矢印）をクリックし、また並び順を変えると以前に矢印が初期化しないバグを修正しました。

## 画面
|  BEFORE |  AFTER |
|---|---|
|  ![ver0 2](https://user-images.githubusercontent.com/7286214/219412790-c5820501-6a4a-4b2c-ad27-69b26b3420fa.gif) | ![ver0 3](https://user-images.githubusercontent.com/7286214/219413914-a6e018f9-ff22-4701-b6ec-cb300db38f5a.gif) |


## やったこと
- stateをClickableHeaderからFrameDataTableHeaderに移動
- isDescendingの変数は不要なので削除（ただisAscendingの逆・・・）

## TODO
- [x] TODOが残ってるので各TODOを解決
- [x] ReadMeの動画を更新
- [ ] 重複コードを削除 （ # で対応）